### PR TITLE
JUnit Jupiter migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
-		<junit.version>4.13.1</junit.version>
+		<junit.version>5.9.1</junit.version>
 		<commons.lang.version>2.6</commons.lang.version>
 		<jacoco.version>0.8.5</jacoco.version>
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -123,6 +123,11 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
 			<!-- Coverage -->
 			<plugin>
 				<groupId>org.jacoco</groupId>
@@ -145,7 +150,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<reporting>
         <plugins>
             <plugin>
@@ -211,8 +216,8 @@
 		</dependency>
 		<!-- testing -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/test/java/com/tupilabs/human_name_parser/BuilderTest.java
+++ b/src/test/java/com/tupilabs/human_name_parser/BuilderTest.java
@@ -23,13 +23,14 @@
  */
 package com.tupilabs.human_name_parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@code HumanNameParserBuilder}.
@@ -142,54 +143,54 @@ public class BuilderTest {
 
     // validations
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorFailsWithNullString() {
-        new HumanNameParserBuilder((String) null);
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder((String) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorFailsWithNullName() {
-        new HumanNameParserBuilder((Name) null);
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder((Name) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullSalutations1() {
-        new HumanNameParserBuilder("john paul").withSalutations(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withSalutations(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullSalutations2() {
-        new HumanNameParserBuilder("john paul").withExtraSalutations(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withExtraSalutations(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullPostnominals1() {
-        new HumanNameParserBuilder("john paul").withPostnominals(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withPostnominals(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullPostnominals2() {
-        new HumanNameParserBuilder("john paul").withExtraPostnominals(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withExtraPostnominals(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullSuffixes1() {
-        new HumanNameParserBuilder("john paul").withSuffixes(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withSuffixes(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullSuffixes2() {
-        new HumanNameParserBuilder("john paul").withExtraSuffixes(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withExtraSuffixes(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullPrefixes1() {
-        new HumanNameParserBuilder("john paul").withPrefixes(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withPrefixes(null).build());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFailsToBuildWithNullPrefixes2() {
-        new HumanNameParserBuilder("john paul").withExtraPrefixes(null).build();
+        assertThrows(NullPointerException.class, () -> new HumanNameParserBuilder("john paul").withExtraPrefixes(null).build());
     }
 
     @Test

--- a/src/test/java/com/tupilabs/human_name_parser/NameTest.java
+++ b/src/test/java/com/tupilabs/human_name_parser/NameTest.java
@@ -23,10 +23,10 @@
  */
 package com.tupilabs.human_name_parser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@code Name} and {@code HumanNameParserParser}. Utilizes the same
@@ -38,7 +38,7 @@ public class NameTest {
 
     protected Name object;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         object = new Name("Bjorn O'Malley");
     }

--- a/src/test/java/com/tupilabs/human_name_parser/ParserTest.java
+++ b/src/test/java/com/tupilabs/human_name_parser/ParserTest.java
@@ -23,7 +23,7 @@
  */
 package com.tupilabs.human_name_parser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,8 +32,8 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ParserTest {
 
@@ -41,7 +41,7 @@ public class ParserTest {
 
     private static File testNames = null;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         testNames = new File(ParserTest.class.getResource("/testNames.txt").getFile());
     }


### PR DESCRIPTION
This PR upgrades the project to use the modern JUnit Jupiter 5.9.1 in order to make it easier for future contributors to write and maintain tests.

It includes:

1. pom.xml 
   1. Replace the dependency `junit:junit:4.10` with the modern `org.junit.jupiter:junit-jupiter.5.9.0`.
   2. Explicitly define the `org.apache.maven.plugins:maven-surefire-plugin:2.22.2` dependency in order to execute JUnit Jupiter tests.
1. Annotations
   1. `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test` in the simple case where the annotation takes no arguments. In the cases the `expected` argument was used the annotation was still replaced, but the assertions had to also be changed, see 3.ii. below. 
   2. `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`. 
   3. `org.junit.jupiter.api.BeforeAll` was used as a drop-in replacement for `org.junit.BeforeAll`.
1. Assertions 
   1. The methods of `org.junit.jupiter.api.Assertions` were used as drop-in replacements for the methods of `org.junit.Assert` with the same name. 
   2. `org.junit.jupiter.api.Assertions`' `assertThrows` was used as a replacement for the `org.junit.Test` annotation with an `expected` argument.