### PR TITLE
Fix for HumanNameParser incorrectly interprets some name components as postnominals

### DIFF
--- a/src/main/java/com/tupilabs/human_name_parser/HumanNameParserBuilder.java
+++ b/src/main/java/com/tupilabs/human_name_parser/HumanNameParserBuilder.java
@@ -137,16 +137,16 @@ public final class HumanNameParserBuilder {
      */
     public HumanNameParserParser build() {
         if (this.salutations == null) {
-            this.salutations = DEFAULT_SALUTATIONS;
+            this.salutations = formatToRegex(DEFAULT_SALUTATIONS);
         }
         if (this.postnominals == null) {
-            this.postnominals = DEFAULT_POSTNOMINALS;
+            this.postnominals = formatToRegex(DEFAULT_POSTNOMINALS);
         }
         if (this.prefixes == null) {
-            this.prefixes = DEFAULT_PREFIXES;
+            this.prefixes = formatToRegex(DEFAULT_PREFIXES);
         }
         if (this.suffixes == null) {
-            this.suffixes = DEFAULT_SUFFIXES;
+            this.suffixes = formatToRegex(DEFAULT_SUFFIXES);
         }
         final HumanNameParserParser parser = new HumanNameParserParser(
             name,
@@ -157,6 +157,14 @@ public final class HumanNameParserBuilder {
         );
         parser.parse();
         return parser;
+    }
+
+    private List<String> formatToRegex(List<String> list) {
+        List<String> regexList = new ArrayList<>();
+        for (String s : list) {
+            regexList.add(s.replace(".", "\\."));
+        }
+        return regexList;
     }
 
     // salutations

--- a/src/test/java/com/tupilabs/human_name_parser/BuilderTest.java
+++ b/src/test/java/com/tupilabs/human_name_parser/BuilderTest.java
@@ -141,6 +141,14 @@ public class BuilderTest {
         assertTrue(parser.salutations.contains("sinho"));
     }
 
+    @Test
+    public void testLastNameNotMistakenForPostnominal() {
+        HumanNameParserBuilder builder = new HumanNameParserBuilder("ruvin phidd");
+        HumanNameParserParser parser = builder.build();
+        assertTrue(parser.getFirst().contains("ruvin"));
+        assertTrue(parser.getLast().contains("phidd"));
+    }
+
     // validations
 
     @Test


### PR DESCRIPTION
# Rationale

Hi. While using this library I observed that names similar to the default postnominals such as "Ruvin Phidd" cannot be parsed correctly, throwing the exception
```
com.tupilabs.human_name_parser.ParseException: Couldn't find a last name in '{ruvin}'.
```

The cause is that the default postnominals
```
    public static final List<String> DEFAULT_POSTNOMINALS = Collections.unmodifiableList(
            Arrays.asList(
                    "phd",
                    "ph.d.",
                    "ph.d",
                    "esq",
                    "esquire",
                    "apr",
                    "rph",
                    "pe",
                    "md",
                    "ma",
                    "dmd",
                    "cme",
                    "dds",
                    "cpa",
                    "dvm"));
```

contains periods (.), which are interpreted as wildcard characters when parsed as regular expressions. As a result, unexpected matches occur during name parsing. The fix included on this PR addresses this problem by formatting the default values on the build() step of `HumanNameParserBuilder`.

# Changes
- Added method `formatToRegex` to `HumanNameParserBuilder` and modified build() to format the default values.
- Created unit test `testLastNameNotMistakenForPostnominal` at `BuilderTest` that catches this problem.
